### PR TITLE
Stops IntoRawFd closing the socket.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,9 @@ impl FromRawFd for Socket {
 
 impl IntoRawFd for Socket {
     fn into_raw_fd(self) -> RawFd {
-        self.fd
+        let fd = self.fd;
+        std::mem::forget(self);
+        fd
     }
 }
 


### PR DESCRIPTION
I don't think socket.into_raw_fd() should close the socket as that seems to make it somewhat pointless.
