### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ zero_copy = ["zerocopy"]
 nix = "0.24"
 error-chain = "0.12"
 serde = { version = "1.0", optional = true }
-serde_cbor = { version = "0", optional = true }
+serde_cbor = { version = "0.11", optional = true }
 serde_json = { version = "1.0", optional = true }
 bincode = { version = "1.0", optional = true }
 zerocopy = { version = "0.6", optional = true }


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.